### PR TITLE
Travis and version from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 
 language: c
 
-compiler: gcc
+compiler:
+  - gcc
+  - clang
 
 script: autoreconf -if && ./configure && make && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ compiler:
   - gcc
   - clang
 
-script: autoreconf -if && ./configure && make && make check
+script: autoreconf -if && ./configure && make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,29 @@ compiler:
   - gcc
   - clang
 
+env:
+  global:
+    secure: "M5SI248QO1XFTVhQXGHUDeUC/mkHj5fo51tDDoUFOwtlV0vMwrk7wb1s4W1PbOZWAkt2gad1Ilfjgv/+l1y2uQSPq08Ih4ubYNdbAXchycDkJnctnNyLCQ/B+4eVJocu9GDeQxfMpOByKfvwCgDhtzeIMV1OfIFtzOdwOySEP5c="
+
 script: autoreconf -if && ./configure && make distcheck
+
+after_success:
+  - export DIST_FILE=$(ls teepot-*.tar.gz)
+  - export MD5_FILE=$DIST_FILE.md5
+  - md5sum $DIST_FILE > $MD5_FILE
+  - export SHA256_FILE=$DIST_FILE.sha256
+  - shasum -a 256 $DIST_FILE > $SHA256_FILE
+
+deploy:
+  provider: releases
+  api-key: $GH_OAUTH
+  file:
+    - $DIST_FILE
+    - $MD5_FILE
+    - $SHA256_FILE
+  skip_cleanup: true
+  on:
+    condition: "$CC = gcc"
+    tags: true
+    all_branches: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+
+language: c
+
+compiler: gcc
+
+script: autoreconf -if && ./configure && make && make check

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ this program. If not, see <http://www.gnu.org/licenses>])
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([teepot], m4_esyscmd([git describe --tags --always --dirty | tr -d '\012']), [])
+AC_INIT([teepot], m4_esyscmd_s([git describe --tags --always --dirty]), [])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ this program. If not, see <http://www.gnu.org/licenses>])
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([teepot], [1.1.1], [])
+AC_INIT([teepot], m4_esyscmd([git describe --tags --always --dirty | tr -d '\012']), [])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_MAINTAINER_MODE


### PR DESCRIPTION
Use Travis for testing (using distcheck) and deployment of tags.
Pick up version from git (when running autoreconf).
